### PR TITLE
Added support for queries that return scalar results

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "upsolver-sdk-python"
-version = "0.1.7"
+version = "0.1.8"
 description = "Python SDK for Upsolver"
 authors = ["Upsolver Team <info@upsolver.com>"]
 

--- a/upsolver/client/poller.py
+++ b/upsolver/client/poller.py
@@ -92,9 +92,14 @@ class SimpleResponsePoller(object):
 
         if 'result' in rjson:
             result = rjson['result']
-            grid = result['grid']  # columns, data, ...
-            column_names = [c['name'] for c in grid['columns']]
-            data_w_columns: ExecutionResult = [dict(zip(column_names, row)) for row in grid['data']]
+            if rjson['kind'] == 'upsolver_scalar_query_response':
+                scalar = result['scalar']
+                column_name = [scalar['valueType']]
+                data_w_columns: ExecutionResult = [dict(zip([column_name], [scalar]))]
+            else:
+                grid = result['grid']  # columns, data, ...
+                column_name = [c['name'] for c in grid['columns']]
+                data_w_columns: ExecutionResult = [dict(zip(column_name, row)) for row in grid['data']]
 
             return data_w_columns, result.get('next')
         else:

--- a/upsolver/dbapi/examples.py
+++ b/upsolver/dbapi/examples.py
@@ -76,3 +76,9 @@ try:
 except BaseException as e:
     print('Caught error on closed connection')
 # %%
+job_name = '' # Job name here
+print('Execute a `SHOW CREATE` statement:')
+result1 = cursor.execute(f'show create job {job_name};')
+print('create job statement:')
+result2 = cursor.fetchone()
+print(result2)

--- a/upsolver/dbapi/utils.py
+++ b/upsolver/dbapi/utils.py
@@ -83,7 +83,12 @@ class DBAPIResponsePoller(SimpleResponsePoller):
 
         if 'result' in rjson:
             result = rjson['result']
-            result['grid']['has_next_page'] = result.get('next') is not None
-            return result['grid'], result.get('next')
+            if rjson['kind'] == 'upsolver_scalar_query_response':
+                scalar = result['scalar']
+                columns = [{'name': scalar['valueType'], 'columnType': {'clazz': 'StringColumnType'}}]
+                return {'columns': columns, 'data': [scalar]}, result.get('next')
+            else:
+                result['grid']['has_next_page'] = result.get('next') is not None
+                return result['grid'], result.get('next')
         else:
             return rjson, None


### PR DESCRIPTION
Queries such as `SHOW CREATE JOB <job_name>` return scalar results. A scalar result is returned as:

```
[
    {
        "status": "Success",
        "kind": "upsolver_scalar_query_response",
        "result":
        {
            "scalar":
            {
                "value": "<value_here>",
                "valueType": "<value_type_here>"
            }
        }
    }
]
```

This commit transforms this result into a 1x1 grid with a column name of
`valueType`.
